### PR TITLE
Surya/Karna: Set TARGET_RELEASE

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -8,6 +8,6 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/aosp_surya.mk
 
 COMMON_LUNCH_CHOICES := \
-    aosp_surya-user \
-    aosp_surya-userdebug \
-    aosp_surya-eng
+    aosp_surya-ap1a-user \
+    aosp_surya-ap1a-userdebug \
+    aosp_surya-ap1a-eng


### PR DESCRIPTION
ap1a since it's the only option at the moment
`
build/make/core/release_config.mk:100: error: No release config set for target; please set TARGET_RELEASE, or if building on the command line use 'lunch <target>-<release>-<build_type>', where release is one of: ap1a.`